### PR TITLE
Fix incomplete zond -> QRL rebrand

### DIFF
--- a/1-deploy.js
+++ b/1-deploy.js
@@ -8,9 +8,9 @@ if(config.hexseed == "hexseed_here") {
     process.exit(1)
 }
 
-const acc = web3.zond.accounts.seedToAccount(config.hexseed)
-web3.zond.wallet?.add(config.hexseed)
-web3.zond.transactionConfirmationBlocks = config.tx_required_confirmations
+const acc = web3.qrl.accounts.seedToAccount(config.hexseed)
+web3.qrl.wallet?.add(config.hexseed)
+web3.qrl.transactionConfirmationBlocks = config.tx_required_confirmations
 
 const receiptHandler = function(receipt){
     console.log("Contract address ", receipt.contractAddress)
@@ -23,14 +23,14 @@ const deployMyTokenContract = async () => {
 
     const contractABI = output.contracts['MyToken.hyp']['MyToken'].abi
     const contractByteCode = output.contracts['MyToken.hyp']['MyToken'].zvm.bytecode.object
-    const contract = new web3.zond.Contract(contractABI)
+    const contract = new web3.qrl.Contract(contractABI)
 
     const deployOptions = {data: contractByteCode, arguments: ["TOKEN123", "TOK"]}
     const contractDeploy = contract.deploy(deployOptions)
     const estimatedGas = await contractDeploy.estimateGas({from: acc.address})
     const txObj = {type: '0x2', gas: estimatedGas, from: acc.address, data: contractDeploy.encodeABI()}
 
-    await web3.zond.sendTransaction(txObj, undefined, { checkRevertBeforeSending: false })
+    await web3.qrl.sendTransaction(txObj, undefined, { checkRevertBeforeSending: false })
     .on('confirmation', console.log)
     .on('receipt', receiptHandler)
     .on('error', console.error)

--- a/2-onchain-call.js
+++ b/2-onchain-call.js
@@ -13,11 +13,11 @@ if(config.contract_address == "contract_address_here") {
     process.exit(1)
 }
 
-const acc = web3.zond.accounts.seedToAccount(config.hexseed)
-web3.zond.wallet?.add(config.hexseed)
-web3.zond.transactionConfirmationBlocks = config.tx_required_confirmations
+const acc = web3.qrl.accounts.seedToAccount(config.hexseed)
+web3.qrl.wallet?.add(config.hexseed)
+web3.qrl.transactionConfirmationBlocks = config.tx_required_confirmations
 
-const receiverAccAddress = "Z2073a9893a8a2c065bf8d0269c577390639ecefa"
+const receiverAccAddress = "Q2073a9893a8a2c065bf8d0269c577390639ecefa"
 
 const transferMyToken = async () => {
     console.log('Attempting to call the contract transfer method from account:', acc.address)
@@ -26,13 +26,13 @@ const transferMyToken = async () => {
 
     const contractABI = output.contracts['MyToken.hyp']['MyToken'].abi
     const contractAddress = config.contract_address
-    const contract = new web3.zond.Contract(contractABI, contractAddress)
+    const contract = new web3.qrl.Contract(contractABI, contractAddress)
 
     const contractTransfer = contract.methods.transfer(receiverAccAddress, 10000)
     const estimatedGas = await contractTransfer.estimateGas({"from": acc.address})
     const txObj = {type: '0x2', gas: estimatedGas, from: acc.address, data: contractTransfer.encodeABI(), to: config.contract_address}
 
-    await web3.zond.sendTransaction(txObj, undefined, { checkRevertBeforeSending: true })
+    await web3.qrl.sendTransaction(txObj, undefined, { checkRevertBeforeSending: true })
     .on('confirmation', console.log)
     .on('receipt', console.log)
     .on('error', console.error)

--- a/3-offchain-call.js
+++ b/3-offchain-call.js
@@ -8,14 +8,14 @@ if(config.contract_address == "contract_address_here") {
     process.exit(1)
 }
 
-const accAddress = "Z2073a9893a8a2c065bf8d0269c577390639ecefa"
+const accAddress = "Q2073a9893a8a2c065bf8d0269c577390639ecefa"
 
 const checkMyTokenBalance = async () => {
     console.log('Attempting to check MyToken balance for account:', accAddress)
 
     const output = contractCompiler.GetCompilerOutput()
     const contractABI = output.contracts['MyToken.hyp']['MyToken'].abi
-    const contract = new web3.zond.Contract(contractABI, config.contract_address)
+    const contract = new web3.qrl.Contract(contractABI, config.contract_address)
     contract.methods.balanceOf(accAddress).call().then((result, error)=>{
         if(error) {
             console.log(error)

--- a/getcode.js
+++ b/getcode.js
@@ -1,10 +1,10 @@
 const Web3 = require('@theqrl/web3')
 const web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:4545'))
 
-const contractAddress = "Zfddea5fdd39fc4d1fafdf5ab3d8220bd7bde6a86"
+const contractAddress = "Qfddea5fdd39fc4d1fafdf5ab3d8220bd7bde6a86"
 
 const getCode = async () => {
-    web3.zond.getCode(contractAddress, function(result, error) {
+    web3.qrl.getCode(contractAddress, function(result, error) {
         if(error) {
             console.log(error)
         } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,78 +10,20 @@
       "license": "ISC",
       "dependencies": {
         "@theqrl/hypc": "^0.0.2",
-        "@theqrl/web3": "^0.3.0"
-      }
-    },
-    "../web3.js/packages/@theqrl/web3": {
-      "extraneous": true
-    },
-    "../web3.js/packages/@theqrl/web3-zond": {
-      "extraneous": true
-    },
-    "../web3.js/packages/@theqrl/web3-zond-accounts": {
-      "extraneous": true
-    },
-    "../web3.js/packages/web3-eth": {
-      "version": "1.7.5",
-      "extraneous": true,
-      "license": "LGPL-3.0",
-      "dependencies": {
-        "web3-core": "1.7.5",
-        "web3-core-helpers": "1.7.5",
-        "web3-core-method": "1.7.5",
-        "web3-core-subscriptions": "1.7.5",
-        "web3-eth-abi": "1.7.5",
-        "web3-eth-accounts": "1.7.5",
-        "web3-eth-contract": "1.7.5",
-        "web3-eth-ens": "1.7.5",
-        "web3-eth-iban": "1.7.5",
-        "web3-eth-personal": "1.7.5",
-        "web3-net": "1.7.5",
-        "web3-utils": "1.7.5"
-      },
-      "devDependencies": {
-        "dtslint": "^3.4.1",
-        "typescript": "^3.9.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "../web3.js/packages/web3-eth-accounts": {
-      "version": "1.7.5",
-      "extraneous": true,
-      "license": "LGPL-3.0",
-      "dependencies": {
-        "@ethereumjs/common": "^2.5.0",
-        "@ethereumjs/tx": "^3.3.2",
-        "crypto-browserify": "3.12.0",
-        "eth-lib": "0.2.8",
-        "ethereumjs-util": "^7.0.10",
-        "scrypt-js": "^3.0.1",
-        "uuid": "3.3.2",
-        "web3-core": "1.7.5",
-        "web3-core-helpers": "1.7.5",
-        "web3-core-method": "1.7.5",
-        "web3-utils": "1.7.5"
-      },
-      "devDependencies": {
-        "dtslint": "^3.4.1",
-        "typescript": "^3.9.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
+        "@theqrl/web3": "^0.4.0"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
-      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
     },
     "node_modules/@ethereumjs/rlp": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-4.0.1.tgz",
       "integrity": "sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==",
+      "license": "MPL-2.0",
       "bin": {
         "rlp": "bin/rlp"
       },
@@ -90,9 +32,9 @@
       }
     },
     "node_modules/@ethersproject/abstract-provider": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
-      "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz",
+      "integrity": "sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==",
       "funding": [
         {
           "type": "individual",
@@ -103,20 +45,21 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/networks": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ethersproject/web": "^5.7.0"
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/networks": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/web": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/abstract-signer": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
-      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz",
+      "integrity": "sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==",
       "funding": [
         {
           "type": "individual",
@@ -127,18 +70,19 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0"
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/address": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
-      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+      "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
       "funding": [
         {
           "type": "individual",
@@ -149,18 +93,19 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/rlp": "^5.7.0"
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/base64": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
-      "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.8.0.tgz",
+      "integrity": "sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==",
       "funding": [
         {
           "type": "individual",
@@ -171,14 +116,15 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/bytes": "^5.7.0"
+        "@ethersproject/bytes": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/bignumber": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
-      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.8.0.tgz",
+      "integrity": "sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==",
       "funding": [
         {
           "type": "individual",
@@ -189,16 +135,17 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
         "bn.js": "^5.2.1"
       }
     },
     "node_modules/@ethersproject/bytes": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
-      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.8.0.tgz",
+      "integrity": "sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==",
       "funding": [
         {
           "type": "individual",
@@ -209,14 +156,15 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/logger": "^5.7.0"
+        "@ethersproject/logger": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/constants": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
-      "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.8.0.tgz",
+      "integrity": "sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==",
       "funding": [
         {
           "type": "individual",
@@ -227,14 +175,15 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0"
+        "@ethersproject/bignumber": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/hash": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
-      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.8.0.tgz",
+      "integrity": "sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==",
       "funding": [
         {
           "type": "individual",
@@ -245,22 +194,23 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/base64": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/keccak256": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
-      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.8.0.tgz",
+      "integrity": "sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==",
       "funding": [
         {
           "type": "individual",
@@ -271,30 +221,16 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/bytes": "^5.8.0",
         "js-sha3": "0.8.0"
       }
     },
     "node_modules/@ethersproject/logger": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
-      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ]
-    },
-    "node_modules/@ethersproject/networks": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
-      "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.8.0.tgz",
+      "integrity": "sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==",
       "funding": [
         {
           "type": "individual",
@@ -305,14 +241,31 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/@ethersproject/networks": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.8.0.tgz",
+      "integrity": "sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/logger": "^5.7.0"
+        "@ethersproject/logger": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/properties": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
-      "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz",
+      "integrity": "sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==",
       "funding": [
         {
           "type": "individual",
@@ -323,14 +276,15 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/logger": "^5.7.0"
+        "@ethersproject/logger": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/rlp": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
-      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.8.0.tgz",
+      "integrity": "sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==",
       "funding": [
         {
           "type": "individual",
@@ -341,15 +295,16 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/signing-key": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
-      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.8.0.tgz",
+      "integrity": "sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==",
       "funding": [
         {
           "type": "individual",
@@ -360,19 +315,20 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
         "bn.js": "^5.2.1",
-        "elliptic": "6.5.4",
+        "elliptic": "6.6.1",
         "hash.js": "1.1.7"
       }
     },
     "node_modules/@ethersproject/strings": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
-      "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.8.0.tgz",
+      "integrity": "sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==",
       "funding": [
         {
           "type": "individual",
@@ -383,16 +339,17 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/transactions": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
-      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.8.0.tgz",
+      "integrity": "sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==",
       "funding": [
         {
           "type": "individual",
@@ -403,22 +360,23 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/rlp": "^5.7.0",
-        "@ethersproject/signing-key": "^5.7.0"
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0",
+        "@ethersproject/signing-key": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/web": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
-      "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.8.0.tgz",
+      "integrity": "sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==",
       "funding": [
         {
           "type": "individual",
@@ -429,73 +387,32 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/base64": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
-    "node_modules/@noble/curves": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
-      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
-      "dependencies": {
-        "@noble/hashes": "1.4.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip32": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
-      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
-      "dependencies": {
-        "@noble/curves": "~1.4.0",
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip39": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
-      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
-      "dependencies": {
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@theqrl/abi": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/abi/-/abi-0.1.0.tgz",
-      "integrity": "sha512-QIJd8UreY+rjS3s2Tjrc6WaTpJV/Ro2k8OEh2OvhPckIiqS4nVPQVhVTahmI6jDi+Qq9b8jtrO+sFD5Snl0+cg==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/abi/-/abi-0.4.4.tgz",
+      "integrity": "sha512-3rG8SNF92KUGC1DR95YkFPI+dv7FC0FVEnMKI4oA0VV+wJnEptHySNIOmYFQNEMu+M+wPrPkT9h8jl5uv2/Iag==",
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/address": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -506,16 +423,10 @@
         "@ethersproject/logger": "^5.7.0",
         "@ethersproject/properties": "^5.7.0",
         "@ethersproject/strings": "^5.7.0",
-        "@theqrl/web3-utils": "^0.3.0"
-      }
-    },
-    "node_modules/@theqrl/dilithium5": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@theqrl/dilithium5/-/dilithium5-0.0.9.tgz",
-      "integrity": "sha512-GZAGr+XBLEcqNKnAMEDSJ7eubJv9Lbv9wfqZ1ELNo2ZFdaeqgeZDN7DxhT23bIyQ1/HWFssbJKHGJMaxFRYZRg==",
-      "dependencies": {
-        "randombytes": "^2.1.0",
-        "sha3": "^2.1.4"
+        "@theqrl/web3-utils": "0.4.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/hypc": {
@@ -535,316 +446,371 @@
         "hypcjs": "hypc.js"
       }
     },
-    "node_modules/@theqrl/wallet.js": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/wallet.js/-/wallet.js-0.1.3.tgz",
-      "integrity": "sha512-MZLWszKmUlG4/unQ0xBPWKgJ6VvUkLycyEvDSrM67NLhejizqtauoEBrNJopfZrfssxUDm0L1K8Bqt7srfcCPA==",
+    "node_modules/@theqrl/mldsa87": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.1.tgz",
+      "integrity": "sha512-BPEvwrrphkMjyPnDorMzQdfrtICTZsiUxiBnwFkv2SfIcQwTTPQV3kTVfidZXXE7033ZCvhu1u5Aiw6TrjxPPQ==",
+      "license": "MIT",
       "dependencies": {
-        "@theqrl/dilithium5": "^0.0.9",
-        "randombytes": "^2.1.0",
-        "sha3": "^2.1.4"
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@theqrl/qrl-cryptography": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/qrl-cryptography/-/qrl-cryptography-0.1.4.tgz",
+      "integrity": "sha512-VB2p4I3fLdAel87HJWAWPekWfgt68OnnQ2csmLtzYE7Xpo5dgjlre3CLgTzvAKclsOlaH/3NZwcORTJI7OPc9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0",
+        "@theqrl/mldsa87": "2.1.3"
+      },
+      "engines": {
+        "node": ">=20.19"
+      }
+    },
+    "node_modules/@theqrl/qrl-cryptography/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@theqrl/qrl-cryptography/node_modules/@theqrl/mldsa87": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.1.3.tgz",
+      "integrity": "sha512-sQxeMZTeJG84v8lK8gRztuHHC2hB6RG2yWQc7oHv19lExG6vB4qvn8nk8/0ffseYXMqfqU5dmZ4jdabk9P3TEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@theqrl/wallet.js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@theqrl/wallet.js/-/wallet.js-2.0.2.tgz",
+      "integrity": "sha512-gqmPE1D7qk2d6Qir0/iZeRGGr2eAVjps9Zql0P4pIw/uBjs81FBYio90c+RawkuKyc2WjlOLF6l3VI02z/rMSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1",
+        "@theqrl/mldsa87": "2.0.1"
       }
     },
     "node_modules/@theqrl/web3": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3/-/web3-0.3.0.tgz",
-      "integrity": "sha512-SH13baAvggYh8ncJ49STFCgUTiNzVqyLjovUeYU+1zkmFzNVUgutC6l5A9tbzU/AooVhmpdZl+TG3GkRrmjoCw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3/-/web3-0.4.4.tgz",
+      "integrity": "sha512-5XHHQP2RXB4BzUuvu1iTRxsRhtYqiXKx1TcyfMuKGFCifykP2jxEt0B2AG9cD8DnbRh6JWmavrDeK/aeu10d+A==",
+      "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-net": "^0.3.0",
-        "@theqrl/web3-providers-http": "^0.3.0",
-        "@theqrl/web3-providers-ws": "^0.3.0",
-        "@theqrl/web3-rpc-methods": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond": "^0.3.0",
-        "@theqrl/web3-zond-abi": "^0.3.0",
-        "@theqrl/web3-zond-accounts": "^0.3.0",
-        "@theqrl/web3-zond-contract": "^0.3.0",
-        "@theqrl/web3-zond-ens": "^0.3.0",
-        "@theqrl/web3-zond-iban": "^0.3.0"
+        "@theqrl/web3-core": "0.4.4",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-net": "0.4.4",
+        "@theqrl/web3-providers-http": "0.4.4",
+        "@theqrl/web3-providers-ws": "0.4.4",
+        "@theqrl/web3-qrl": "0.4.4",
+        "@theqrl/web3-qrl-abi": "0.4.4",
+        "@theqrl/web3-qrl-accounts": "0.4.4",
+        "@theqrl/web3-qrl-contract": "0.4.4",
+        "@theqrl/web3-qrl-iban": "0.4.4",
+        "@theqrl/web3-qrl-qrns": "0.4.4",
+        "@theqrl/web3-rpc-methods": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4"
       },
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-core/-/web3-core-0.3.0.tgz",
-      "integrity": "sha512-nwOUx1hXUjeyaFwUA1GkzudF7cfmyAv8F6HnartlVM8Y+Tdhqy+tLr/XV8XkmiMmIHC7qEkmuq2GtPKCGANqng==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-core/-/web3-core-0.4.4.tgz",
+      "integrity": "sha512-GgIe3U/6NhONG7YKlYp1HzjFt8gkGwfbPac6HKDqJVpQo1dd2pNjcWUfP4EFa3YP5748xnatStQrSCBx76gg5w==",
+      "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-providers-http": "^0.3.0",
-        "@theqrl/web3-providers-ws": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond-iban": "^0.3.0"
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-providers-http": "0.4.4",
+        "@theqrl/web3-providers-ws": "0.4.4",
+        "@theqrl/web3-qrl-iban": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       },
       "optionalDependencies": {
-        "@theqrl/web3-providers-ipc": "^0.3.0"
+        "@theqrl/web3-providers-ipc": "0.4.4"
       }
     },
     "node_modules/@theqrl/web3-errors": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-0.3.0.tgz",
-      "integrity": "sha512-fZy77nXaubf+37ghegl36F4Ws1xRdyDXAPpgCaa1Y06M9hYwYyPvkrKGm+zo7OykvC7P/2EYtwSIjGlm+oSgnA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-0.4.3.tgz",
+      "integrity": "sha512-tazXfP8xZdzr3MwaH6o6kLn+64CYhUS+2ybufTanVqL+YoErIwMyPQQaL/t4GBMTHypFDSy4AVRfEQLvCw+Z9w==",
+      "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-types": "^0.3.0"
+        "@theqrl/web3-types": "0.4.3"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-net": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-net/-/web3-net-0.3.0.tgz",
-      "integrity": "sha512-mdu+WosHOea3kc0oTPztGnx+Q0WubK6LWkAj6TMe5XptlqBDdc61SqieRHgF097hKntYz8EJeYMTka3X0I4+9A==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-net/-/web3-net-0.4.4.tgz",
+      "integrity": "sha512-AeEFBYzYbJI16Iap3Td9GybFj9rAvkqCFbJYKQp4IJSWWgsEJYHcevig57cahTmeiYpNscbrmrL0jPQAI+m3Cg==",
+      "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-rpc-methods": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0"
+        "@theqrl/web3-core": "0.4.4",
+        "@theqrl/web3-rpc-methods": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-http": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-http/-/web3-providers-http-0.3.0.tgz",
-      "integrity": "sha512-PQAUO/SDaJQdge0wwI5ZvQlXAh3ZaqeF4/+ARTawDZhjxT64qGmz1/n8hH0M4Kn9a/VL4UC/0GBZSpZK1uGsKg==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-http/-/web3-providers-http-0.4.4.tgz",
+      "integrity": "sha512-Ol6usX4HWWPStTkfUIhdSmnGX9XZ6RciwG8mOBWkw/A0KL50LE137C+uAOb36NMK7tO/vF2E5xHdFCGM2d705g==",
+      "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
         "cross-fetch": "^3.1.5"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ipc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ipc/-/web3-providers-ipc-0.3.0.tgz",
-      "integrity": "sha512-1QyX3DB18OennQ10wctvsabLJiHu8tQZG+LezqLm3v9+8yc6uSAlGmX1B4rXtb1VsvoF4klbq9iGYdVRVEmM2w==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ipc/-/web3-providers-ipc-0.4.4.tgz",
+      "integrity": "sha512-Dd4vOKZ3YnoiR5HJHBQse+xbeQ4zc+r9MFHs4mKalh+3oeqB3TCQOfN7NImoB2dUBMmThUlyz0C0uw0mVL7IVw==",
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0"
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ws": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ws/-/web3-providers-ws-0.3.0.tgz",
-      "integrity": "sha512-4y2hlnI3y0MA1v30x8n0naUK+zyMmNUL9ImNphGQIVxP2GotQEAaSJvJEkcNQccMAdGg/bS990l7vVf+gSQ5eQ==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ws/-/web3-providers-ws-0.4.4.tgz",
+      "integrity": "sha512-AAlNywppRAZcygAro7Q0Vu7b7loCjtKdtH61EIVwKjfcAqpJFDnCCrIZ+qiLlAZO09fFuYHwzx6O4KUgzTqgfA==",
+      "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
         "@types/ws": "8.5.3",
         "isomorphic-ws": "^5.0.0",
-        "ws": "^8.8.1"
+        "ws": "^8.17.1"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
-    "node_modules/@theqrl/web3-rpc-methods": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-rpc-methods/-/web3-rpc-methods-0.3.0.tgz",
-      "integrity": "sha512-K4rWxYl0kauUgsb/nJqh2ra1W0DKYd2Yhwh8OLbDzVPWCLhX7DKliXt1zTUbNHy0fL/B6y3Qpu1OI4L9yb3KPQ==",
+    "node_modules/@theqrl/web3-qrl": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl/-/web3-qrl-0.4.4.tgz",
+      "integrity": "sha512-kBJhW3AJf5wabjuNz3kpo0CJFaO6m2Rayf7YKyYKhbIfX6fzUBOWRaL6gpFj7onR9KlO0vvHO3Lb4pXZFw6Ekw==",
+      "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "node_modules/@theqrl/web3-types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-0.3.0.tgz",
-      "integrity": "sha512-tiIxISN6vh6wzeT9FwrBzTn91BbQjFwuu2nJ3NIQTUKOermY7shiJ9cy/t4CFYIYrNqxj03tlHNpRqecAU4tbQ==",
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "node_modules/@theqrl/web3-utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-0.3.0.tgz",
-      "integrity": "sha512-b4J0nbufN981mz/5RVNGNzQinm1jRff2VCW4x8z1YxNffr52eCB7h0LD5/ua/fBVdy0QEv2eI7b2Eh4KmlGj4g==",
-      "dependencies": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "ethereum-cryptography": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "node_modules/@theqrl/web3-validator": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-0.3.0.tgz",
-      "integrity": "sha512-xX5Kywwi63wZY3YOj0CW7ysFKZxqXB9SciHfU+nezK4Z4lFSjiN6eawp+lciJnCT+qbpvoB3e+Z/x+5WRal79w==",
-      "dependencies": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "ethereum-cryptography": "^2.0.0",
-        "util": "^0.12.5",
-        "zod": "^3.21.4"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "node_modules/@theqrl/web3-zond": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond/-/web3-zond-0.3.0.tgz",
-      "integrity": "sha512-KOduhIfudlA1WXsBCaOLViD+WjaKRU/UaxysvthfdUN6NZgiwZsx//1zlwWDyxJS1c8TLmTBhl5qxKKhQMJ8AQ==",
-      "dependencies": {
-        "@theqrl/wallet.js": "^0.1.0",
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-net": "^0.3.0",
-        "@theqrl/web3-providers-ws": "^0.3.0",
-        "@theqrl/web3-rpc-methods": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond-abi": "^0.3.0",
-        "@theqrl/web3-zond-accounts": "^0.3.0",
+        "@theqrl/wallet.js": "^2.0.2",
+        "@theqrl/web3-core": "0.4.4",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-net": "0.4.4",
+        "@theqrl/web3-providers-ws": "0.4.4",
+        "@theqrl/web3-qrl-abi": "0.4.4",
+        "@theqrl/web3-qrl-accounts": "0.4.4",
+        "@theqrl/web3-rpc-methods": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4",
         "setimmediate": "^1.0.5"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
-    "node_modules/@theqrl/web3-zond-abi": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-abi/-/web3-zond-abi-0.3.0.tgz",
-      "integrity": "sha512-wnQXnFhcx/4zCeLt4vZA0g4phFIOvkEMMfmTwSXnNfhatSnCUtsW7cZ1UxCB6j87HGQ8FPeTee4D3SoVwj6z/A==",
+    "node_modules/@theqrl/web3-qrl-abi": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-abi/-/web3-qrl-abi-0.4.4.tgz",
+      "integrity": "sha512-aI1vFF+SwDq+dOnq9AHDtAw+zHaJUqAY2PVfCvgAlbseZh26Hl/qSL27YxNN2hCZOJoHVSa3du44TZxO1qrtYA==",
+      "license": "LGPL-3.0",
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",
-        "@theqrl/abi": "^0.1.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "node_modules/@theqrl/web3-zond-accounts": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-accounts/-/web3-zond-accounts-0.3.0.tgz",
-      "integrity": "sha512-jkwFsqjDRafBjrnOsnX8FIjK9Xqp45FhSc4228Of+8hv74RG6CVkzG7XIWGhW24fvriK8ihXqcCg0yq6oUlwZA==",
-      "dependencies": {
-        "@ethereumjs/rlp": "^4.0.1",
-        "@theqrl/dilithium5": "^0.0.9",
-        "@theqrl/wallet.js": "^0.1.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
+        "@theqrl/abi": "0.4.4",
+        "@theqrl/wallet.js": "^2.0.2",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4",
         "crc-32": "^1.2.2",
-        "ethereum-cryptography": "^2.0.0",
         "sha3": "^2.1.4"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
-    "node_modules/@theqrl/web3-zond-contract": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-contract/-/web3-zond-contract-0.3.0.tgz",
-      "integrity": "sha512-cPcFxRlQRyqotXiuLA7qYEKWLCJedM3tXtOB02qHuVR6aEDMyAAITvqAS6qzQG6zbitmtE5XfHJurQm4R3kGiQ==",
+    "node_modules/@theqrl/web3-qrl-accounts": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-accounts/-/web3-qrl-accounts-0.4.4.tgz",
+      "integrity": "sha512-0FpoMl56A+xbjuaNUCWFtpEa59T2bhuUuX+j/2zD6bYvGFO1z/DFVdhWVAFihUxZCjSwuM6p01d+azjqvMkTNg==",
+      "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond": "^0.3.0",
-        "@theqrl/web3-zond-abi": "^0.3.0"
+        "@ethereumjs/rlp": "^4.0.1",
+        "@theqrl/mldsa87": "^2.0.1",
+        "@theqrl/qrl-cryptography": "^0.1.0",
+        "@theqrl/wallet.js": "^2.0.2",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4",
+        "crc-32": "^1.2.2",
+        "sha3": "^2.1.4"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
-    "node_modules/@theqrl/web3-zond-ens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-ens/-/web3-zond-ens-0.3.0.tgz",
-      "integrity": "sha512-W3qpm5jFwKfVm6qv01C0JIZXSicB2zjedUmMe8/Bz3AGo3zqTjY7SFsrj5D9m9M8JRTs8zUHxN6v2o8BzOsHLA==",
+    "node_modules/@theqrl/web3-qrl-contract": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-contract/-/web3-qrl-contract-0.4.4.tgz",
+      "integrity": "sha512-dcsgwPZvV7bZGaUp9o/FDOMPmBd1unWccau/6fa8jYV8fiWcX+dgQrg8kjC0B+Qdr2ePAx9tMYzKCl1AxHVCtw==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@theqrl/web3-core": "0.4.4",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-qrl": "0.4.4",
+        "@theqrl/web3-qrl-abi": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl-iban": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-iban/-/web3-qrl-iban-0.4.4.tgz",
+      "integrity": "sha512-9vg2VELTkA54CeMEEhE79VTVTXULTxFSOKmyl0d9+HL77EDx8hl8FL7FWbwgKYvI5RXJ3osRifNTdugPE2qGNQ==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl-qrns": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-qrns/-/web3-qrl-qrns-0.4.4.tgz",
+      "integrity": "sha512-lfOkrSWQidwGU2IvSWBTzo6mVFjOieUlyR7/1M0z3HyN0NOgPx8SDy6LNv2EJjBZkWzCS5e6NsLptiXq5it/Dw==",
+      "license": "LGPL-3.0",
       "dependencies": {
         "@adraffy/ens-normalize": "^1.8.8",
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-net": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond": "^0.3.0",
-        "@theqrl/web3-zond-contract": "^0.3.0"
+        "@theqrl/web3-core": "0.4.4",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-net": "0.4.4",
+        "@theqrl/web3-qrl": "0.4.4",
+        "@theqrl/web3-qrl-contract": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
       }
     },
-    "node_modules/@theqrl/web3-zond-iban": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-iban/-/web3-zond-iban-0.3.0.tgz",
-      "integrity": "sha512-mHCmFWPdu/i2I+eE+nAwh/eQvK7QYaF5INUzSQ3c0gh/G2ubViSVtxpL9QpzZ9Y0KyRLYZoALjopEpnGlshQhg==",
+    "node_modules/@theqrl/web3-rpc-methods": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-rpc-methods/-/web3-rpc-methods-0.4.4.tgz",
+      "integrity": "sha512-Ris/b0I1LkQhIh/8PBKwR9tONGhlhjV+559vmCZYmsRdyg1RwKI943H6Jk9EBdB6/yPBshGGPhPi2sV3V7i65g==",
+      "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0"
+        "@theqrl/web3-core": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-validator": "0.4.4"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
+        "node": ">=20"
+      }
+    },
+    "node_modules/@theqrl/web3-types": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-0.4.3.tgz",
+      "integrity": "sha512-8RV7QN4Qx+4sjrfkNWguJsZ/P8W19zvQWkr35YmzonG+WDdEYBINIfnSt1Lxy0pcNNSpRUQ+EwdomVmMH11vmA==",
+      "license": "LGPL-3.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@theqrl/web3-utils": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-0.4.4.tgz",
+      "integrity": "sha512-3efGY0HhE0selNoawGbnHW/7tm3cHSK0gIedxjvIMDCQeRnhmd6nNfMAWk3GUA0H3CwGc96SHo+XP3yMDw51+Q==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@theqrl/qrl-cryptography": "^0.1.0",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-validator": "0.4.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@theqrl/web3-validator": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-0.4.4.tgz",
+      "integrity": "sha512-XhG5bnXDEdhzODDFen1ZBWTkqkeUaotdJWfzWbOHXeWKXHRuqSIPluLYgLt/Ph+s8VyPd0W+frafJi7oBsUXcw==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@theqrl/qrl-cryptography": "^0.1.0",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "util": "^0.12.5",
+        "zod": "3.22.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@types/node": {
-      "version": "22.13.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
-      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
+      "version": "22.20.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.2.tgz",
+      "integrity": "sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
       "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -853,6 +819,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -880,17 +847,20 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/bn.js": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
+      "integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==",
+      "license": "MIT"
     },
     "node_modules/brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "license": "MIT"
     },
     "node_modules/buffer": {
       "version": "6.0.3",
@@ -910,33 +880,21 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/bufferutil": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz",
-      "integrity": "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==",
-      "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -950,6 +908,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -959,12 +918,13 @@
       }
     },
     "node_modules/call-bound": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -990,6 +950,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -1001,6 +962,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
       "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.7.0"
       }
@@ -1009,6 +971,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -1025,6 +988,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -1035,9 +999,10 @@
       }
     },
     "node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -1049,14 +1014,16 @@
       }
     },
     "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -1065,30 +1032,21 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/ethereum-cryptography": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
-      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
-      "dependencies": {
-        "@noble/curves": "1.4.2",
-        "@noble/hashes": "1.4.0",
-        "@scure/bip32": "1.4.0",
-        "@scure/bip39": "1.3.0"
       }
     },
     "node_modules/follow-redirects": {
@@ -1114,6 +1072,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
       },
@@ -1128,21 +1087,32 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-intrinsic": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
@@ -1159,6 +1129,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -1171,6 +1142,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -1182,6 +1154,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -1193,6 +1166,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -1204,6 +1178,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -1218,15 +1193,17 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -1238,6 +1215,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "license": "MIT",
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -1261,17 +1239,20 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
       "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
@@ -1287,6 +1268,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -1295,12 +1277,14 @@
       }
     },
     "node_modules/is-generator-function": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
-      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.0",
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
         "has-tostringtag": "^1.0.2",
         "safe-regex-test": "^1.1.0"
       },
@@ -1315,6 +1299,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "gopd": "^1.2.0",
@@ -1332,6 +1317,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
       },
@@ -1346,6 +1332,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
       "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
       "peerDependencies": {
         "ws": "*"
       }
@@ -1359,6 +1346,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -1374,17 +1362,20 @@
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "license": "MIT"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -1400,18 +1391,6 @@
         }
       }
     },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -1424,41 +1403,16 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -1483,6 +1437,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -1498,12 +1453,14 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/sha3": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.4.tgz",
       "integrity": "sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==",
+      "license": "MIT",
       "dependencies": {
         "buffer": "6.0.3"
       }
@@ -1522,31 +1479,20 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
-    },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
       "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -1558,26 +1504,30 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
-      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "for-each": "^0.3.3",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },
@@ -1589,9 +1539,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1609,74 +1560,20 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "web3.js/packages/@theqrl/web3": {
-      "extraneous": true
-    },
-    "web3.js/packages/@theqrl/web3-zond-accounts": {
-      "extraneous": true
-    },
-    "web3.js/packages/web3": {
-      "version": "1.7.5",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "LGPL-3.0",
-      "dependencies": {
-        "web3-bzz": "1.7.5",
-        "web3-core": "1.7.5",
-        "web3-eth": "1.7.5",
-        "web3-eth-personal": "1.7.5",
-        "web3-net": "1.7.5",
-        "web3-shh": "1.7.5",
-        "web3-utils": "1.7.5"
-      },
-      "devDependencies": {
-        "@types/node": "^12.12.6",
-        "dtslint": "^3.4.1",
-        "typescript": "^3.9.5",
-        "web3-core-helpers": "1.7.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "web3.js/packages/web3-eth-accounts": {
-      "version": "1.7.5",
-      "extraneous": true,
-      "license": "LGPL-3.0",
-      "dependencies": {
-        "@ethereumjs/common": "^2.5.0",
-        "@ethereumjs/tx": "^3.3.2",
-        "crypto-browserify": "3.12.0",
-        "eth-lib": "0.2.8",
-        "ethereumjs-util": "^7.0.10",
-        "scrypt-js": "^3.0.1",
-        "uuid": "3.3.2",
-        "web3-core": "1.7.5",
-        "web3-core-helpers": "1.7.5",
-        "web3-core-method": "1.7.5",
-        "web3-utils": "1.7.5"
-      },
-      "devDependencies": {
-        "dtslint": "^3.4.1",
-        "typescript": "^3.9.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     }
   },
   "dependencies": {
     "@adraffy/ens-normalize": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
-      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="
     },
     "@ethereumjs/rlp": {
       "version": "4.0.1",
@@ -1684,224 +1581,192 @@
       "integrity": "sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw=="
     },
     "@ethersproject/abstract-provider": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
-      "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz",
+      "integrity": "sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==",
       "requires": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/networks": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ethersproject/web": "^5.7.0"
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/networks": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/web": "^5.8.0"
       }
     },
     "@ethersproject/abstract-signer": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
-      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz",
+      "integrity": "sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0"
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0"
       }
     },
     "@ethersproject/address": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
-      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+      "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
       "requires": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/rlp": "^5.7.0"
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0"
       }
     },
     "@ethersproject/base64": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
-      "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.8.0.tgz",
+      "integrity": "sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.7.0"
+        "@ethersproject/bytes": "^5.8.0"
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
-      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.8.0.tgz",
+      "integrity": "sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==",
       "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
         "bn.js": "^5.2.1"
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
-      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.8.0.tgz",
+      "integrity": "sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==",
       "requires": {
-        "@ethersproject/logger": "^5.7.0"
+        "@ethersproject/logger": "^5.8.0"
       }
     },
     "@ethersproject/constants": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
-      "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.8.0.tgz",
+      "integrity": "sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==",
       "requires": {
-        "@ethersproject/bignumber": "^5.7.0"
+        "@ethersproject/bignumber": "^5.8.0"
       }
     },
     "@ethersproject/hash": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
-      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.8.0.tgz",
+      "integrity": "sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/base64": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
       }
     },
     "@ethersproject/keccak256": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
-      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.8.0.tgz",
+      "integrity": "sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==",
       "requires": {
-        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/bytes": "^5.8.0",
         "js-sha3": "0.8.0"
       }
     },
     "@ethersproject/logger": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
-      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig=="
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.8.0.tgz",
+      "integrity": "sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA=="
     },
     "@ethersproject/networks": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
-      "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.8.0.tgz",
+      "integrity": "sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==",
       "requires": {
-        "@ethersproject/logger": "^5.7.0"
+        "@ethersproject/logger": "^5.8.0"
       }
     },
     "@ethersproject/properties": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
-      "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz",
+      "integrity": "sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==",
       "requires": {
-        "@ethersproject/logger": "^5.7.0"
+        "@ethersproject/logger": "^5.8.0"
       }
     },
     "@ethersproject/rlp": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
-      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.8.0.tgz",
+      "integrity": "sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==",
       "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
       }
     },
     "@ethersproject/signing-key": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
-      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.8.0.tgz",
+      "integrity": "sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==",
       "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
         "bn.js": "^5.2.1",
-        "elliptic": "6.5.4",
+        "elliptic": "6.6.1",
         "hash.js": "1.1.7"
       }
     },
     "@ethersproject/strings": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
-      "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.8.0.tgz",
+      "integrity": "sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==",
       "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
       }
     },
     "@ethersproject/transactions": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
-      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.8.0.tgz",
+      "integrity": "sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==",
       "requires": {
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/rlp": "^5.7.0",
-        "@ethersproject/signing-key": "^5.7.0"
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0",
+        "@ethersproject/signing-key": "^5.8.0"
       }
     },
     "@ethersproject/web": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
-      "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.8.0.tgz",
+      "integrity": "sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==",
       "requires": {
-        "@ethersproject/base64": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
-    "@noble/curves": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
-      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
-      "requires": {
-        "@noble/hashes": "1.4.0"
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
       }
     },
     "@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="
-    },
-    "@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="
-    },
-    "@scure/bip32": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
-      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
-      "requires": {
-        "@noble/curves": "~1.4.0",
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      }
-    },
-    "@scure/bip39": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
-      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
-      "requires": {
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="
     },
     "@theqrl/abi": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/abi/-/abi-0.1.0.tgz",
-      "integrity": "sha512-QIJd8UreY+rjS3s2Tjrc6WaTpJV/Ro2k8OEh2OvhPckIiqS4nVPQVhVTahmI6jDi+Qq9b8jtrO+sFD5Snl0+cg==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/abi/-/abi-0.4.4.tgz",
+      "integrity": "sha512-3rG8SNF92KUGC1DR95YkFPI+dv7FC0FVEnMKI4oA0VV+wJnEptHySNIOmYFQNEMu+M+wPrPkT9h8jl5uv2/Iag==",
       "requires": {
         "@ethersproject/address": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -1912,16 +1777,7 @@
         "@ethersproject/logger": "^5.7.0",
         "@ethersproject/properties": "^5.7.0",
         "@ethersproject/strings": "^5.7.0",
-        "@theqrl/web3-utils": "^0.3.0"
-      }
-    },
-    "@theqrl/dilithium5": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@theqrl/dilithium5/-/dilithium5-0.0.9.tgz",
-      "integrity": "sha512-GZAGr+XBLEcqNKnAMEDSJ7eubJv9Lbv9wfqZ1ELNo2ZFdaeqgeZDN7DxhT23bIyQ1/HWFssbJKHGJMaxFRYZRg==",
-      "requires": {
-        "randombytes": "^2.1.0",
-        "sha3": "^2.1.4"
+        "@theqrl/web3-utils": "0.4.4"
       }
     },
     "@theqrl/hypc": {
@@ -1938,240 +1794,275 @@
         "tmp": "0.0.33"
       }
     },
-    "@theqrl/wallet.js": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/wallet.js/-/wallet.js-0.1.3.tgz",
-      "integrity": "sha512-MZLWszKmUlG4/unQ0xBPWKgJ6VvUkLycyEvDSrM67NLhejizqtauoEBrNJopfZrfssxUDm0L1K8Bqt7srfcCPA==",
+    "@theqrl/mldsa87": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.1.tgz",
+      "integrity": "sha512-BPEvwrrphkMjyPnDorMzQdfrtICTZsiUxiBnwFkv2SfIcQwTTPQV3kTVfidZXXE7033ZCvhu1u5Aiw6TrjxPPQ==",
       "requires": {
-        "@theqrl/dilithium5": "^0.0.9",
-        "randombytes": "^2.1.0",
-        "sha3": "^2.1.4"
+        "@noble/hashes": "2.0.1"
+      }
+    },
+    "@theqrl/qrl-cryptography": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/qrl-cryptography/-/qrl-cryptography-0.1.4.tgz",
+      "integrity": "sha512-VB2p4I3fLdAel87HJWAWPekWfgt68OnnQ2csmLtzYE7Xpo5dgjlre3CLgTzvAKclsOlaH/3NZwcORTJI7OPc9w==",
+      "requires": {
+        "@noble/hashes": "2.2.0",
+        "@theqrl/mldsa87": "2.1.3"
+      },
+      "dependencies": {
+        "@noble/hashes": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+          "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="
+        },
+        "@theqrl/mldsa87": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.1.3.tgz",
+          "integrity": "sha512-sQxeMZTeJG84v8lK8gRztuHHC2hB6RG2yWQc7oHv19lExG6vB4qvn8nk8/0ffseYXMqfqU5dmZ4jdabk9P3TEg==",
+          "requires": {
+            "@noble/hashes": "2.2.0"
+          }
+        }
+      }
+    },
+    "@theqrl/wallet.js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@theqrl/wallet.js/-/wallet.js-2.0.2.tgz",
+      "integrity": "sha512-gqmPE1D7qk2d6Qir0/iZeRGGr2eAVjps9Zql0P4pIw/uBjs81FBYio90c+RawkuKyc2WjlOLF6l3VI02z/rMSg==",
+      "requires": {
+        "@noble/hashes": "2.0.1",
+        "@theqrl/mldsa87": "2.0.1"
       }
     },
     "@theqrl/web3": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3/-/web3-0.3.0.tgz",
-      "integrity": "sha512-SH13baAvggYh8ncJ49STFCgUTiNzVqyLjovUeYU+1zkmFzNVUgutC6l5A9tbzU/AooVhmpdZl+TG3GkRrmjoCw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3/-/web3-0.4.4.tgz",
+      "integrity": "sha512-5XHHQP2RXB4BzUuvu1iTRxsRhtYqiXKx1TcyfMuKGFCifykP2jxEt0B2AG9cD8DnbRh6JWmavrDeK/aeu10d+A==",
       "requires": {
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-net": "^0.3.0",
-        "@theqrl/web3-providers-http": "^0.3.0",
-        "@theqrl/web3-providers-ws": "^0.3.0",
-        "@theqrl/web3-rpc-methods": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond": "^0.3.0",
-        "@theqrl/web3-zond-abi": "^0.3.0",
-        "@theqrl/web3-zond-accounts": "^0.3.0",
-        "@theqrl/web3-zond-contract": "^0.3.0",
-        "@theqrl/web3-zond-ens": "^0.3.0",
-        "@theqrl/web3-zond-iban": "^0.3.0"
+        "@theqrl/web3-core": "0.4.4",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-net": "0.4.4",
+        "@theqrl/web3-providers-http": "0.4.4",
+        "@theqrl/web3-providers-ws": "0.4.4",
+        "@theqrl/web3-qrl": "0.4.4",
+        "@theqrl/web3-qrl-abi": "0.4.4",
+        "@theqrl/web3-qrl-accounts": "0.4.4",
+        "@theqrl/web3-qrl-contract": "0.4.4",
+        "@theqrl/web3-qrl-iban": "0.4.4",
+        "@theqrl/web3-qrl-qrns": "0.4.4",
+        "@theqrl/web3-rpc-methods": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4"
       }
     },
     "@theqrl/web3-core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-core/-/web3-core-0.3.0.tgz",
-      "integrity": "sha512-nwOUx1hXUjeyaFwUA1GkzudF7cfmyAv8F6HnartlVM8Y+Tdhqy+tLr/XV8XkmiMmIHC7qEkmuq2GtPKCGANqng==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-core/-/web3-core-0.4.4.tgz",
+      "integrity": "sha512-GgIe3U/6NhONG7YKlYp1HzjFt8gkGwfbPac6HKDqJVpQo1dd2pNjcWUfP4EFa3YP5748xnatStQrSCBx76gg5w==",
       "requires": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-providers-http": "^0.3.0",
-        "@theqrl/web3-providers-ipc": "^0.3.0",
-        "@theqrl/web3-providers-ws": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond-iban": "^0.3.0"
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-providers-http": "0.4.4",
+        "@theqrl/web3-providers-ipc": "0.4.4",
+        "@theqrl/web3-providers-ws": "0.4.4",
+        "@theqrl/web3-qrl-iban": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4"
       }
     },
     "@theqrl/web3-errors": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-0.3.0.tgz",
-      "integrity": "sha512-fZy77nXaubf+37ghegl36F4Ws1xRdyDXAPpgCaa1Y06M9hYwYyPvkrKGm+zo7OykvC7P/2EYtwSIjGlm+oSgnA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-0.4.3.tgz",
+      "integrity": "sha512-tazXfP8xZdzr3MwaH6o6kLn+64CYhUS+2ybufTanVqL+YoErIwMyPQQaL/t4GBMTHypFDSy4AVRfEQLvCw+Z9w==",
       "requires": {
-        "@theqrl/web3-types": "^0.3.0"
+        "@theqrl/web3-types": "0.4.3"
       }
     },
     "@theqrl/web3-net": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-net/-/web3-net-0.3.0.tgz",
-      "integrity": "sha512-mdu+WosHOea3kc0oTPztGnx+Q0WubK6LWkAj6TMe5XptlqBDdc61SqieRHgF097hKntYz8EJeYMTka3X0I4+9A==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-net/-/web3-net-0.4.4.tgz",
+      "integrity": "sha512-AeEFBYzYbJI16Iap3Td9GybFj9rAvkqCFbJYKQp4IJSWWgsEJYHcevig57cahTmeiYpNscbrmrL0jPQAI+m3Cg==",
       "requires": {
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-rpc-methods": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0"
+        "@theqrl/web3-core": "0.4.4",
+        "@theqrl/web3-rpc-methods": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4"
       }
     },
     "@theqrl/web3-providers-http": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-http/-/web3-providers-http-0.3.0.tgz",
-      "integrity": "sha512-PQAUO/SDaJQdge0wwI5ZvQlXAh3ZaqeF4/+ARTawDZhjxT64qGmz1/n8hH0M4Kn9a/VL4UC/0GBZSpZK1uGsKg==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-http/-/web3-providers-http-0.4.4.tgz",
+      "integrity": "sha512-Ol6usX4HWWPStTkfUIhdSmnGX9XZ6RciwG8mOBWkw/A0KL50LE137C+uAOb36NMK7tO/vF2E5xHdFCGM2d705g==",
       "requires": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
         "cross-fetch": "^3.1.5"
       }
     },
     "@theqrl/web3-providers-ipc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ipc/-/web3-providers-ipc-0.3.0.tgz",
-      "integrity": "sha512-1QyX3DB18OennQ10wctvsabLJiHu8tQZG+LezqLm3v9+8yc6uSAlGmX1B4rXtb1VsvoF4klbq9iGYdVRVEmM2w==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ipc/-/web3-providers-ipc-0.4.4.tgz",
+      "integrity": "sha512-Dd4vOKZ3YnoiR5HJHBQse+xbeQ4zc+r9MFHs4mKalh+3oeqB3TCQOfN7NImoB2dUBMmThUlyz0C0uw0mVL7IVw==",
       "optional": true,
       "requires": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0"
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4"
       }
     },
     "@theqrl/web3-providers-ws": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ws/-/web3-providers-ws-0.3.0.tgz",
-      "integrity": "sha512-4y2hlnI3y0MA1v30x8n0naUK+zyMmNUL9ImNphGQIVxP2GotQEAaSJvJEkcNQccMAdGg/bS990l7vVf+gSQ5eQ==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ws/-/web3-providers-ws-0.4.4.tgz",
+      "integrity": "sha512-AAlNywppRAZcygAro7Q0Vu7b7loCjtKdtH61EIVwKjfcAqpJFDnCCrIZ+qiLlAZO09fFuYHwzx6O4KUgzTqgfA==",
       "requires": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
         "@types/ws": "8.5.3",
         "isomorphic-ws": "^5.0.0",
-        "ws": "^8.8.1"
+        "ws": "^8.17.1"
       }
     },
-    "@theqrl/web3-rpc-methods": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-rpc-methods/-/web3-rpc-methods-0.3.0.tgz",
-      "integrity": "sha512-K4rWxYl0kauUgsb/nJqh2ra1W0DKYd2Yhwh8OLbDzVPWCLhX7DKliXt1zTUbNHy0fL/B6y3Qpu1OI4L9yb3KPQ==",
+    "@theqrl/web3-qrl": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl/-/web3-qrl-0.4.4.tgz",
+      "integrity": "sha512-kBJhW3AJf5wabjuNz3kpo0CJFaO6m2Rayf7YKyYKhbIfX6fzUBOWRaL6gpFj7onR9KlO0vvHO3Lb4pXZFw6Ekw==",
       "requires": {
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0"
-      }
-    },
-    "@theqrl/web3-types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-0.3.0.tgz",
-      "integrity": "sha512-tiIxISN6vh6wzeT9FwrBzTn91BbQjFwuu2nJ3NIQTUKOermY7shiJ9cy/t4CFYIYrNqxj03tlHNpRqecAU4tbQ=="
-    },
-    "@theqrl/web3-utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-0.3.0.tgz",
-      "integrity": "sha512-b4J0nbufN981mz/5RVNGNzQinm1jRff2VCW4x8z1YxNffr52eCB7h0LD5/ua/fBVdy0QEv2eI7b2Eh4KmlGj4g==",
-      "requires": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "ethereum-cryptography": "^2.0.0"
-      }
-    },
-    "@theqrl/web3-validator": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-0.3.0.tgz",
-      "integrity": "sha512-xX5Kywwi63wZY3YOj0CW7ysFKZxqXB9SciHfU+nezK4Z4lFSjiN6eawp+lciJnCT+qbpvoB3e+Z/x+5WRal79w==",
-      "requires": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "ethereum-cryptography": "^2.0.0",
-        "util": "^0.12.5",
-        "zod": "^3.21.4"
-      }
-    },
-    "@theqrl/web3-zond": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond/-/web3-zond-0.3.0.tgz",
-      "integrity": "sha512-KOduhIfudlA1WXsBCaOLViD+WjaKRU/UaxysvthfdUN6NZgiwZsx//1zlwWDyxJS1c8TLmTBhl5qxKKhQMJ8AQ==",
-      "requires": {
-        "@theqrl/wallet.js": "^0.1.0",
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-net": "^0.3.0",
-        "@theqrl/web3-providers-ws": "^0.3.0",
-        "@theqrl/web3-rpc-methods": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond-abi": "^0.3.0",
-        "@theqrl/web3-zond-accounts": "^0.3.0",
+        "@theqrl/wallet.js": "^2.0.2",
+        "@theqrl/web3-core": "0.4.4",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-net": "0.4.4",
+        "@theqrl/web3-providers-ws": "0.4.4",
+        "@theqrl/web3-qrl-abi": "0.4.4",
+        "@theqrl/web3-qrl-accounts": "0.4.4",
+        "@theqrl/web3-rpc-methods": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4",
         "setimmediate": "^1.0.5"
       }
     },
-    "@theqrl/web3-zond-abi": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-abi/-/web3-zond-abi-0.3.0.tgz",
-      "integrity": "sha512-wnQXnFhcx/4zCeLt4vZA0g4phFIOvkEMMfmTwSXnNfhatSnCUtsW7cZ1UxCB6j87HGQ8FPeTee4D3SoVwj6z/A==",
+    "@theqrl/web3-qrl-abi": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-abi/-/web3-qrl-abi-0.4.4.tgz",
+      "integrity": "sha512-aI1vFF+SwDq+dOnq9AHDtAw+zHaJUqAY2PVfCvgAlbseZh26Hl/qSL27YxNN2hCZOJoHVSa3du44TZxO1qrtYA==",
       "requires": {
         "@ethersproject/bignumber": "^5.7.0",
-        "@theqrl/abi": "^0.1.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0"
-      }
-    },
-    "@theqrl/web3-zond-accounts": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-accounts/-/web3-zond-accounts-0.3.0.tgz",
-      "integrity": "sha512-jkwFsqjDRafBjrnOsnX8FIjK9Xqp45FhSc4228Of+8hv74RG6CVkzG7XIWGhW24fvriK8ihXqcCg0yq6oUlwZA==",
-      "requires": {
-        "@ethereumjs/rlp": "^4.0.1",
-        "@theqrl/dilithium5": "^0.0.9",
-        "@theqrl/wallet.js": "^0.1.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
+        "@theqrl/abi": "0.4.4",
+        "@theqrl/wallet.js": "^2.0.2",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4",
         "crc-32": "^1.2.2",
-        "ethereum-cryptography": "^2.0.0",
         "sha3": "^2.1.4"
       }
     },
-    "@theqrl/web3-zond-contract": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-contract/-/web3-zond-contract-0.3.0.tgz",
-      "integrity": "sha512-cPcFxRlQRyqotXiuLA7qYEKWLCJedM3tXtOB02qHuVR6aEDMyAAITvqAS6qzQG6zbitmtE5XfHJurQm4R3kGiQ==",
+    "@theqrl/web3-qrl-accounts": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-accounts/-/web3-qrl-accounts-0.4.4.tgz",
+      "integrity": "sha512-0FpoMl56A+xbjuaNUCWFtpEa59T2bhuUuX+j/2zD6bYvGFO1z/DFVdhWVAFihUxZCjSwuM6p01d+azjqvMkTNg==",
       "requires": {
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond": "^0.3.0",
-        "@theqrl/web3-zond-abi": "^0.3.0"
+        "@ethereumjs/rlp": "^4.0.1",
+        "@theqrl/mldsa87": "^2.0.1",
+        "@theqrl/qrl-cryptography": "^0.1.0",
+        "@theqrl/wallet.js": "^2.0.2",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4",
+        "crc-32": "^1.2.2",
+        "sha3": "^2.1.4"
       }
     },
-    "@theqrl/web3-zond-ens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-ens/-/web3-zond-ens-0.3.0.tgz",
-      "integrity": "sha512-W3qpm5jFwKfVm6qv01C0JIZXSicB2zjedUmMe8/Bz3AGo3zqTjY7SFsrj5D9m9M8JRTs8zUHxN6v2o8BzOsHLA==",
+    "@theqrl/web3-qrl-contract": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-contract/-/web3-qrl-contract-0.4.4.tgz",
+      "integrity": "sha512-dcsgwPZvV7bZGaUp9o/FDOMPmBd1unWccau/6fa8jYV8fiWcX+dgQrg8kjC0B+Qdr2ePAx9tMYzKCl1AxHVCtw==",
+      "requires": {
+        "@theqrl/web3-core": "0.4.4",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-qrl": "0.4.4",
+        "@theqrl/web3-qrl-abi": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4"
+      }
+    },
+    "@theqrl/web3-qrl-iban": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-iban/-/web3-qrl-iban-0.4.4.tgz",
+      "integrity": "sha512-9vg2VELTkA54CeMEEhE79VTVTXULTxFSOKmyl0d9+HL77EDx8hl8FL7FWbwgKYvI5RXJ3osRifNTdugPE2qGNQ==",
+      "requires": {
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4"
+      }
+    },
+    "@theqrl/web3-qrl-qrns": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-qrns/-/web3-qrl-qrns-0.4.4.tgz",
+      "integrity": "sha512-lfOkrSWQidwGU2IvSWBTzo6mVFjOieUlyR7/1M0z3HyN0NOgPx8SDy6LNv2EJjBZkWzCS5e6NsLptiXq5it/Dw==",
       "requires": {
         "@adraffy/ens-normalize": "^1.8.8",
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-net": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond": "^0.3.0",
-        "@theqrl/web3-zond-contract": "^0.3.0"
+        "@theqrl/web3-core": "0.4.4",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-net": "0.4.4",
+        "@theqrl/web3-qrl": "0.4.4",
+        "@theqrl/web3-qrl-contract": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-utils": "0.4.4",
+        "@theqrl/web3-validator": "0.4.4"
       }
     },
-    "@theqrl/web3-zond-iban": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-iban/-/web3-zond-iban-0.3.0.tgz",
-      "integrity": "sha512-mHCmFWPdu/i2I+eE+nAwh/eQvK7QYaF5INUzSQ3c0gh/G2ubViSVtxpL9QpzZ9Y0KyRLYZoALjopEpnGlshQhg==",
+    "@theqrl/web3-rpc-methods": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-rpc-methods/-/web3-rpc-methods-0.4.4.tgz",
+      "integrity": "sha512-Ris/b0I1LkQhIh/8PBKwR9tONGhlhjV+559vmCZYmsRdyg1RwKI943H6Jk9EBdB6/yPBshGGPhPi2sV3V7i65g==",
       "requires": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0"
+        "@theqrl/web3-core": "0.4.4",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-validator": "0.4.4"
+      }
+    },
+    "@theqrl/web3-types": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-0.4.3.tgz",
+      "integrity": "sha512-8RV7QN4Qx+4sjrfkNWguJsZ/P8W19zvQWkr35YmzonG+WDdEYBINIfnSt1Lxy0pcNNSpRUQ+EwdomVmMH11vmA=="
+    },
+    "@theqrl/web3-utils": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-0.4.4.tgz",
+      "integrity": "sha512-3efGY0HhE0selNoawGbnHW/7tm3cHSK0gIedxjvIMDCQeRnhmd6nNfMAWk3GUA0H3CwGc96SHo+XP3yMDw51+Q==",
+      "requires": {
+        "@theqrl/qrl-cryptography": "^0.1.0",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "@theqrl/web3-validator": "0.4.4"
+      }
+    },
+    "@theqrl/web3-validator": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-0.4.4.tgz",
+      "integrity": "sha512-XhG5bnXDEdhzODDFen1ZBWTkqkeUaotdJWfzWbOHXeWKXHRuqSIPluLYgLt/Ph+s8VyPd0W+frafJi7oBsUXcw==",
+      "requires": {
+        "@theqrl/qrl-cryptography": "^0.1.0",
+        "@theqrl/web3-errors": "0.4.3",
+        "@theqrl/web3-types": "0.4.3",
+        "util": "^0.12.5",
+        "zod": "3.22.3"
       }
     },
     "@types/node": {
-      "version": "22.13.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
-      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
+      "version": "22.20.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.2.tgz",
+      "integrity": "sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==",
       "requires": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "@types/ws": {
@@ -2196,9 +2087,9 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bn.js": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
+      "integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg=="
     },
     "brorand": {
       "version": "1.1.0",
@@ -2214,24 +2105,14 @@
         "ieee754": "^1.2.1"
       }
     },
-    "bufferutil": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz",
-      "integrity": "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "node-gyp-build": "^4.3.0"
-      }
-    },
     "call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "requires": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       }
     },
@@ -2245,12 +2126,12 @@
       }
     },
     "call-bound": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "requires": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       }
     },
     "command-exists": {
@@ -2297,9 +2178,9 @@
       }
     },
     "elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "requires": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -2311,9 +2192,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.12.1",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-          "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+          "version": "4.12.5",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+          "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="
         }
       }
     },
@@ -2328,22 +2209,11 @@
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
     },
     "es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "requires": {
         "es-errors": "^1.3.0"
-      }
-    },
-    "ethereum-cryptography": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
-      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
-      "requires": {
-        "@noble/curves": "1.4.2",
-        "@noble/hashes": "1.4.0",
-        "@scure/bip32": "1.4.0",
-        "@scure/bip39": "1.3.0"
       }
     },
     "follow-redirects": {
@@ -2364,17 +2234,22 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
+    "generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="
+    },
     "get-intrinsic": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "requires": {
-        "call-bind-apply-helpers": "^1.0.1",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
@@ -2426,9 +2301,9 @@
       }
     },
     "hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "requires": {
         "function-bind": "^1.1.2"
       }
@@ -2468,12 +2343,13 @@
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
     "is-generator-function": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
-      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
       "requires": {
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.0",
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
         "has-tostringtag": "^1.0.2",
         "safe-regex-test": "^1.1.0"
       }
@@ -2536,13 +2412,6 @@
         "whatwg-url": "^5.0.0"
       }
     },
-    "node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "optional": true,
-      "peer": true
-    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -2552,19 +2421,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
-    },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safe-regex-test": {
       "version": "1.1.0",
@@ -2621,19 +2477,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
-    },
-    "utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "node-gyp-build": "^4.3.0"
-      }
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "util": {
       "version": "0.12.5",
@@ -2662,28 +2508,29 @@
       }
     },
     "which-typed-array": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
-      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "requires": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "for-each": "^0.3.3",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       }
     },
     "ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "requires": {}
     },
     "zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@theqrl/web3": "^0.3.0",
+    "@theqrl/web3": "^0.4.0",
     "@theqrl/hypc": "^0.0.2"
   }
 }


### PR DESCRIPTION
Fixes #12.

### Problem

The example scripts don't run against Testnet V2 as-is:

1. `package.json` pinned `@theqrl/web3@^0.3.0`, which derives
   Z-prefixed addresses — Testnet V2 uses Q-prefixed.
2. `1-deploy.js`, `2-onchain-call.js`, and `3-offchain-call.js` call the
   pre-rebrand `web3.zond.*` namespace; the library renamed it to
   `web3.qrl.*`.
3. Hardcoded example addresses in `2-onchain-call.js` and
   `3-offchain-call.js` are Z-prefixed.

### Fix

Exactly what #12 specified, plus one more instance it didn't list:

- `package.json`: `@theqrl/web3` `^0.3.0` → `^0.4.0` (resolves to
  `0.4.4`).
- `web3.zond` → `web3.qrl` in all three scripts named in the issue.
- Z-prefixed → Q-prefixed addresses in both files named in the issue.

**Also fixed `getcode.js`**, which has the identical
`web3.zond.getCode(...)` / Z-prefixed-address pattern but wasn't in the
issue's list — as written it's dead code today (its only call targets a
namespace that only exists on `web3@0.3.x`), so I updated it for
consistency with the other three scripts.

### Verification

```
$ npm install
# @theqrl/web3 resolves to 0.4.4, no dependency conflicts

$ node --check 1-deploy.js 2-onchain-call.js 3-offchain-call.js getcode.js
# all pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)